### PR TITLE
#105 Block auth users from auth screens

### DIFF
--- a/src/hooks/useAuthCheckRedirect.js
+++ b/src/hooks/useAuthCheckRedirect.js
@@ -13,6 +13,29 @@ export const useRedirectNonAuthUserToSigninPage = () => {
   }, [appManager.isAuthenticated, replace]);
 };
 
+const handleRedirectUserToRoleScreen = (appManager, replace) => {
+  if (appManager.state.user && appManager.state.metadata) {
+    const { userRoleId, departmentId } = appManager.state.user;
+    const role = appManager.getOneMetadata("userRoles", userRoleId);
+
+    console.log(
+      !/admin/i.test(role?.name),
+      role?.name,
+      appManager.state.user,
+      appManager.state
+    );
+
+    if (!/admin/i.test(role?.name)) {
+      return replace("/");
+    }
+    if (departmentId) {
+      return replace("/");
+    }
+
+    replace("/admin");
+  }
+};
+
 export const useRedirectAuthUserToRoleScreens = (timeout = 0) => {
   useRedirectNonAuthUserToSigninPage();
 
@@ -21,18 +44,7 @@ export const useRedirectAuthUserToRoleScreens = (timeout = 0) => {
 
   useEffect(() => {
     const handleRedirect = () => {
-      if (appManager.state.user && appManager.state.metadata) {
-        const { userRoleId, departmentId } = appManager.state.user;
-        const role = appManager.getOneMetadata("userRoles", userRoleId);
-
-        if (!/admin/i.test(role?.name)) {
-          return replace("/");
-        }
-        if (departmentId) {
-          return replace("/");
-        }
-        replace("/admin");
-      }
+      handleRedirectUserToRoleScreen(appManager, replace);
     };
 
     const timeoutId = setTimeout(handleRedirect, timeout);
@@ -79,7 +91,13 @@ export const useBlockAuthenticatedUserFromPage = () =>
       // }
 
       if (appManager.isAuthenticated) {
-        replace("/courses");
+        handleRedirectUserToRoleScreen(appManager, replace);
       }
-    }, [appManager.isAuthenticated, replace]);
+    }, [
+      replace,
+      appManager,
+      appManager.isAuthenticated,
+      appManager.state.user,
+      appManager.state.metadata,
+    ]);
   };


### PR DESCRIPTION
#### What does this PR do?
 
Redirect the user from:
- `/auth/signin`
- `/auth/forgot-password`

#### How should this be manually tested?

1. Clone the repository.
2. `cd` into it and RUN ` npm install`.
3. RUN `npm run start`.
4. Open the browser, and go to `http://localhost:3000`.

#### What are the relevant pivotal tracker stories?

#77 #105 