### PR TITLE
fix: remove unnecessary comment from department name heading

### DIFF
--- a/src/pages/admin/departments/ViewDepartmentDetails.jsx
+++ b/src/pages/admin/departments/ViewDepartmentDetails.jsx
@@ -90,7 +90,7 @@ const ViewDepartmentPage = () => {
       </Box>
 
       <Heading fontSize="heading.h3" paddingX={6}>
-        {department?.name} ///
+        {department?.name}
       </Heading>
 
       <Box


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where "///" appeared after department names in the header on the Department Details page in the admin area. Titles now display cleanly and consistently. This is a visual correction only; no changes to data, permissions, routing, or other functionality. Improves overall page readability and professional appearance for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->